### PR TITLE
file/dir navigation in selector

### DIFF
--- a/lib/complete-ng.bash
+++ b/lib/complete-ng.bash
@@ -12,58 +12,11 @@ _arrayread() {
     set -f; eval "$1"'=($(cat))'; set +f
 }
 
-_complete-ng_navigate() {
-  local dir=$1 IFS="$IFS"
-  [[ "$dir" = \~/* ]] && dir="$HOME/"${dir#\~/}
-  [ -d "$dir" ] || return 1
-  dir=$(\cd "$dir" >/dev/null 2>&1 && pwd) || return 1
-  [[ $dir = $PWD* ]] && dir="${dir#$PWD}" && dir="${dir#/}"
-  [ "$dir" ] && dir="${dir%/}/"
-  [[ "$dir" = $HOME/* ]] && dir="~/${dir#$HOME/}"
-  _items="$(compgen "$compgen_opt" -- "$dir"|sort -u)"
-  [ "$_items" ] || _items="${dir%/}/"
-  _items_ori="$_items"
-  return 0
-}
-
 _complete-ng_key() {
   local k="$1" item="${_aitems[$_nsel]}"
-  [[ "$item" = \~* ]] && item="$(IFS=;eval printf %s '~'$(printf %q ${item#\~}))"
-  [[ "$item" = \$[A-Za-z0-9_]* ]] && item="$(IFS=;eval printf %s '$'$(printf %q ${item#\$}))"
+  _path_expand "$item"
+  item="$_path_expand"
   case "$k" in
-    $'\t') # tab
-      selected="$item"
-      return 1
-    ;;
-    '[C'|OC) # right
-      _complete-ng_navigate "$item" || return 3
-      return 0
-    ;;
-    '[D'|OD) # left
-      [ -e "$item" ] || return 3
-      [[ "$item" = */* ]] && item="${item%/*}" || item=.
-      _complete-ng_navigate "$item/.." || return 3
-      return 0
-    ;;
-    '²')
-      _items=$(printf "%s\n" "${_aitems[@]}"|grep -E -v '^\.[^/]|/\.')
-      [ "$_items" ] || return 1
-      return 0
-    ;;
-    'OR') # F3
-      _force_nsel=$_nsel
-      [ -r "$item" ] && [ -f "$item" ] || return 0
-      ${PAGER:-less -+EX} "$item"
-      _tput civis
-      return 0
-    ;;
-    'OS') # F4
-      _force_nsel=$_nsel
-      [ -r "$item" ] && [ -f "$item" ] || return 0
-      ${EDITOR:-vi} "$item"
-      _tput civis
-      return 0
-    ;;
     '[19~'|$'\x04'|'[3~') # F8 Ctl-D Del
       [ "$COMP_DELFUNC" ] && $COMP_DELFUNC "${item%%$'\t'*}"
     ;;
@@ -82,7 +35,7 @@ _complete-ng() {
         fn=$(eval printf '%s' '$'_compfunc_"${cmd//[^a-zA-Z0-9_]/_}")
     }
   }
-  [ "$cmd" = 'cd' ] && compgen_opt='-d'
+  [ "$cmd" = 'cd' ] && compgen_opt='-d' && selopt=(-o dirnames)
   [ "$fn" ] && $fn "$@"
   (( ${#COMPREPLY[@]} > 0 )) || {
     type "compopt" >/dev/null 2>&1 && compopt -o filenames 2>/dev/null || \
@@ -172,6 +125,6 @@ _complete-ng_init() {
 }
 
 : "${COMPLETE_NG_EXCLUDE:=_cdhist_cd}"
-type cdcomplete >/dev/null 2>&1 && cdcomplete
+#type cdcomplete >/dev/null 2>&1 && cdcomplete
 _complete-ng_init
 

--- a/lib/complete-ng.zsh
+++ b/lib/complete-ng.zsh
@@ -206,9 +206,9 @@ _complete_ng_post() {
 }
 
 _complete_ng_selector() {
-    local lines=() reply REPLY
+    local lines=() reply REPLY sel_option=filenames
     exec {tty}</dev/tty
-
+    [[ ${words[1]} = (cd|cdpush) ]] && sel_option=dirnames
     while (( ${#lines[@]} < 2 )); do
         zselect -r 0 "$tty"
         if (( reply[2] == 0 )); then
@@ -227,7 +227,7 @@ _complete_ng_selector() {
         fi
     done
 
-    local item items longword selected s n
+    local item items longword selected s n tilde
     IFS=$'\n' lines+=($(cat)); IFS=$' \t\n'
     declare -A values
     items=()
@@ -242,7 +242,7 @@ _complete_ng_selector() {
     if (( ${#items[@]} > 1 )) ;then
         printf $'\n' >/dev/tty
         longword="$(sed -e 's/\t.*//' -e '$!{N;s/^\(.*\).*\n\1.*$/\1\n\1/;D;}' <<<"${(F)items}")"
-        SELECTOR_CASEI="$COMPLETE_NG_CASEI" selector -m 10 -k _complete-ng_key -i "${(F)items}" -o filenames -F "$longword" >/dev/null
+        SELECTOR_CASEI="$COMPLETE_NG_CASEI" selector -m 10 -k _complete-ng_key -i "${(F)items}" -o $sel_option -F "$longword" >/dev/null
         code="$?"
         _tput cuu1 >/dev/tty
         [ ! "$selected" ] && [ "$longword" != "$PREFIX" ] && code="0" && selected="$longword"
@@ -253,63 +253,17 @@ _complete_ng_selector() {
     [ "$code" = 0 ] || return $code
     n="${values[$selected]}"
     [ "$n" ] && line="${lines[$n]}}" || {
-        s="$(printf '%q' "${(q)selected}")"
-        s="${s/#\\\\~\//~/}"
+        [[ $selected = ~* ]] && tilde='~'
+        s="$(printf '%s%q' "$tilde" "${(q)selected#\~}")"
         line="${(q)selected}${_COMPLETE_NG_SEP}$s${_COMPLETE_NG_SEP}100${_COMPLETE_NG_SEP}"
     }
     printf %s "$line"
     return 0
 }
-_complete-ng_navigate() {
-  local dir="$1" IFS="$IFS"
-  [[ "$dir" = \~/* ]] && dir="$HOME/${dir#\~/}"
-  [ -d "$dir" ] || return 1
-  dir=$(\cd "$dir" >/dev/null 2>&1 && pwd) || return 1
-  [[ $dir = $PWD* ]] && dir="${dir#$PWD}" && dir="${dir#/}"
-  [ "$dir" ] && dir="${dir%/}/"
-  _items="$(setopt NULL_GLOB; print -rl -- $~dir* $~dir.*|sort -u|sed -e "s#^$HOME/#~/#")"
-  [ "$_items" ] || _items="${dir%/}"
-  _items_ori="$_items"
-  return 0
-}
+
 _complete-ng_key() {
   local k="$1" item="${_aitems[$_nsel]}"
-  [[ "$item" = \~* ]] && item="$(IFS=;eval printf %s '~'$(printf %q ${item#\~}))"
-  [[ "$item" = \$[A-Za-z0-9_]* ]] && item="$(IFS=;eval printf %s '$'$(printf %q ${item#\$}))"
   case "$k" in
-    $'\t') # tab
-      selected="$item"
-      return 1
-    ;;
-    '[C'|OC) # right
-      _complete-ng_navigate "$item" || return 3
-      return 0
-    ;;
-    '[D'|OD) # left
-      [ -e "$item" ] || return 3
-      [[ "$item" = */* ]] && item="${item%/*}" || item=.
-      _complete-ng_navigate "$item/.." || return 3
-      return 0
-    ;;
-    '²')
-      _items=$(printf "%s\n" "${_aitems[@]}"|egrep -v '^\.[^/]|/\.')
-      [ "$_items" ] || return 1
-      return 0
-    ;;
-    'OR') # F3
-      _force_nsel=$_nsel
-      [ -r "$item" ] && [ -f "$item" ] || return 0
-      less -+EX "$item"
-      _tput civis
-      return 0
-    ;;
-    'OS') # F4
-      _force_nsel=$_nsel
-      [ -r "$item" ] && [ -f "$item" ] || return 0
-      ${EDITOR:-vi} "$item"
-      _tput civis
-      return 0
-    ;;
     '[19~'|$'\x04'|'[3~') # F8 Ctl-D Del
       [[ $_COMPLETE_NG_CONTEXT = *:_fly,ssh* ]] && COMP_DELFUNC=_fly_hist_del
       [ "$COMP_DELFUNC" ] && $COMP_DELFUNC "${item%%$'\t'*}"

--- a/lib/complete-ng.zsh
+++ b/lib/complete-ng.zsh
@@ -156,6 +156,7 @@ _complete_ng() {
               | "$_complete_ng_awk" -W interactive -F"$_COMPLETE_NG_SEP" '/^$/{exit}; $1!="" && !x[$1]++ { print $0; system("") }' 2>/dev/null
         )
         coproc_pid="$!"
+set >/tmp/set 2>&1
         __value="$(_complete_ng_selector "$__code" <&p)"
         __code="$?"
         kill -- -"$coproc_pid" 2>/dev/null && wait "$coproc_pid"
@@ -206,9 +207,10 @@ _complete_ng_post() {
 }
 
 _complete_ng_selector() {
-    local lines=() reply REPLY sel_option=filenames
+    local lines=() reply REPLY selopt=(-o filenames)
     exec {tty}</dev/tty
-    [[ ${words[1]} = (cd|cdpush) ]] && sel_option=dirnames
+    [[ ${words[1]} = (cd|cdpush) ]] && selopt=(-o dirnames)
+    [[ ${words[$CURRENT]} = -* ]] && selopt=()
     while (( ${#lines[@]} < 2 )); do
         zselect -r 0 "$tty"
         if (( reply[2] == 0 )); then
@@ -242,7 +244,7 @@ _complete_ng_selector() {
     if (( ${#items[@]} > 1 )) ;then
         printf $'\n' >/dev/tty
         longword="$(sed -e 's/\t.*//' -e '$!{N;s/^\(.*\).*\n\1.*$/\1\n\1/;D;}' <<<"${(F)items}")"
-        SELECTOR_CASEI="$COMPLETE_NG_CASEI" selector -m 10 -k _complete-ng_key -i "${(F)items}" -o $sel_option -F "$longword" >/dev/null
+        SELECTOR_CASEI="$COMPLETE_NG_CASEI" selector -m 10 -k _complete-ng_key -i "${(F)items}" ${selopt[@]} -F "$longword" >/dev/null
         code="$?"
         _tput cuu1 >/dev/tty
         [ ! "$selected" ] && [ "$longword" != "$PREFIX" ] && code="0" && selected="$longword"

--- a/lib/complete-ng.zsh
+++ b/lib/complete-ng.zsh
@@ -156,7 +156,6 @@ _complete_ng() {
               | "$_complete_ng_awk" -W interactive -F"$_COMPLETE_NG_SEP" '/^$/{exit}; $1!="" && !x[$1]++ { print $0; system("") }' 2>/dev/null
         )
         coproc_pid="$!"
-set >/tmp/set 2>&1
         __value="$(_complete_ng_selector "$__code" <&p)"
         __code="$?"
         kill -- -"$coproc_pid" 2>/dev/null && wait "$coproc_pid"
@@ -207,10 +206,9 @@ _complete_ng_post() {
 }
 
 _complete_ng_selector() {
-    local lines=() reply REPLY selopt=(-o filenames)
+    local lines=() reply REPLY selopt=()
     exec {tty}</dev/tty
-    [[ ${words[1]} = (cd|cdpush) ]] && selopt=(-o dirnames)
-    [[ ${words[$CURRENT]} = -* ]] && selopt=()
+
     while (( ${#lines[@]} < 2 )); do
         zselect -r 0 "$tty"
         if (( reply[2] == 0 )); then
@@ -239,8 +237,10 @@ _complete_ng_selector() {
         item="${value[5]}"
         values[$item]=$i
         [ "${value[4]}" ] && item+=$'\t'"${value[4]#*  -- }"
+        [ "${value[7]}" = '-f' ] && selopt=(-o filenames)
         items[i]="$item"
     done
+    [[ ${words[1]} = (cd|cdpush) ]] && selopt=(-o dirnames)
     if (( ${#items[@]} > 1 )) ;then
         printf $'\n' >/dev/tty
         longword="$(sed -e 's/\t.*//' -e '$!{N;s/^\(.*\).*\n\1.*$/\1\n\1/;D;}' <<<"${(F)items}")"
@@ -290,6 +290,7 @@ _complete_ng_compadd() {
     local __noquote="${__flags[(r)-Q]}"
     local __is_param="${__flags[(r)-e]}"
     local __no_matching="${__flags[(r)-U]}"
+
     if [ -n "${__optskv[(i)-A]}${__optskv[(i)-O]}${__optskv[(i)-D]}" ]; then
         # handle -O -A -D
         builtin compadd "${__flags[@]}" "${__opts[@]}" "${__ipre[@]}" "${__hpre[@]}" -- "$@"
@@ -376,7 +377,7 @@ _complete_ng_compadd() {
         __show_str+="${_COMPLETE_NG_SEP}"
 
         # fullvalue, value, index, display, show, prefix
-        printf %s\\n "${(q)prefix}${(q)__real_str}${(q)__suffix}${_COMPLETE_NG_SEP}${(q)__hit_str}${_COMPLETE_NG_SEP}${__comp_index}${_COMPLETE_NG_SEP}${__disp_str}${_COMPLETE_NG_SEP}${(Q)prefix}${__show_str}${_COMPLETE_NG_SPACE_SEP}" >&"${__stdout}"
+        printf %s\\n "${(q)prefix}${(q)__real_str}${(q)__suffix}${_COMPLETE_NG_SEP}${(q)__hit_str}${_COMPLETE_NG_SEP}${__comp_index}${_COMPLETE_NG_SEP}${__disp_str}${_COMPLETE_NG_SEP}${(Q)prefix}${__show_str}${_COMPLETE_NG_SEP}$__filenames${_COMPLETE_NG_SEP}" >&"${__stdout}"
     done
     return "$__code"
 }

--- a/lib/seedee
+++ b/lib/seedee
@@ -167,37 +167,24 @@ function cdhist {
 # expand arg without alias expansion
 # use bash_completion _cd or limited cdcomplete
 _cdhist_cd() {
-  typeset row col word="${COMP_WORDS[1]}" dir IFS=$' \t\n' ts='~/' hs="$HOME/" longword
+  typeset row col word="${COMP_WORDS[1]}" dir IFS=$' \t\n' ts='~/' hs="$HOME/" longword prefix
   [ "$COMP_CWORD" = 1 ] || return 1
-  [[ "$word" = @($|~)[a-zA-Z0-9_/]* ]] && dir="$(eval printf %s "$word")"
-  [ "$dir" ] && {
-    dir="${dir/#$hs/$ts}"
-    COMP_WORDS=( "$1" "$dir" )
-    COMP_LINE="$(printf '%s ' "${COMP_WORDS[@]}")"
-    COMP_LINE="${COMP_LINE% }"
-    COMP_POINT=${#COMP_LINE}
-  }
   if declare -F _cd >/dev/null; then
     _cd "$1" "${COMP_WORDS[1]}"
   else
     type compopt >/dev/null 2>&1 && compopt -o filenames 2>/dev/null || \
         compgen -f /non-existing-dir/ >/dev/null
-    dir="${dir/#$ts/$hs}"
-    COMP_WORDS=( cd "$dir" )
-    [ "$dir" = ".." ] && dir="../"
+    [ "$word" = ".." ] && word="../"
+    _path_expand "$word";dir="$_path_expand"
+    [[ "$word" = */* ]] && prefix="${word%/*}/" 
     word="${dir##*/}"
     [[ "$dir" = */* ]] && dir="${dir%/*}" || dir='.'
     : ${dir:=/}
     IFS=$'\n'
     set -f
-    COMPREPLY=( $(\cd "$dir" >/dev/null 2>&1 && compgen -d -- "$word") ) 
+    COMPREPLY=( $(\cd "$dir" >/dev/null 2>&1 && compgen -d -P "$prefix" -- "$word") ) 
     set +f
     IFS=$' \t\n'
-    [ ! "${COMPREPLY[0]}" ] && COMPREPLY=() && return
-    dir="${dir%/}/"
-    [ "$dir" = ./ ] && [[ ${COMP_WORDS[1]} != ./* ]] && dir=""
-    COMPREPLY=( "${COMPREPLY[@]/#/$dir}" )
-    # COMP_WORDS=( cd "$dir$word" )
   fi
   [ ${#COMPREPLY[@]} = 1 ] && {
     COMPREPLY[0]="${COMPREPLY[0]/#$ts/$hs}"

--- a/lib/seedee
+++ b/lib/seedee
@@ -64,7 +64,7 @@ function cdselect
     [ "$_cdpr" = 1 ] && [ "$BASH" ] && _tput el >&2
     printf "\n" >&2
   }
-  dir="$(selector -P "$CDPOWERLINE" -m "$nb" -p cd -k _cd_keys -o filenames -F "$filter" -i "$2")"
+  dir="$(selector -P "$CDPOWERLINE" -m "$nb" -k _cd_keys -p cd -o dirnames -F "$filter" -i "$2")"
   [ "$_cdpr" ] && {
     _tput cuu1 >&2
     # bash 3/4 bug repeating prompt/command
@@ -87,7 +87,7 @@ _cdbrowse() {
   $(\cd "$dir" >/dev/null 2>&1) || return
   [ "$depth" = 4 ] && printf "Searching directories..." >&2
   _items="$(find -L "$dir" -xdev -mindepth 1 -maxdepth "$depth" -type d -print 2>/dev/null|\
-    sed -e s"#^$HOME/#\~/#"|sort)"
+    sed -e s"#^$HOME/#\~/#" -e 's#^\./##'|sort)"
   _items_ori="$_items"
 }
 
@@ -97,53 +97,9 @@ _cd_keys()
   typeset k="$1" dir="${_aitems[$_nsel]}"
 
   case "$k" in
-    $'\t') # tab
-      selected="$dir"
-      return 1
-    ;;
-    '[C'|OC) # right
-      [ ! "$filter" ] && _last_nsel=$_nsel
-      _cdbrowse "$dir"
-      [ "$_items" ] || _items="${dir%/}/"
-      return 0
-    ;;
-    '[D'|OD) # left    
-      [[ "$dir" = \~* ]] && dir="$HOME"${dir#\~}
-      [[ "$dir" = */* ]] && dir="${dir%/*}" || dir="."
-      : ${dir:=/}
-      [ "$(\cd "$dir" >/dev/null;pwd)" = / ] && dir=/
-      case "$dir" in
-        .)   dir='..';;
-        *(../)..|..) dir="$dir/..";;
-        */*) dir="${dir%/*}";: ${dir:=/};;
-        *) dir='.';;
-      esac
-      _cdbrowse "$dir"
-      _force_nsel=$_last_nsel
-      unset _last_nsel
-      return 0
-    ;;
-    '[1;2C') # shift right
-      [[ "$dir" = \~* ]] && dir="$HOME"${dir#\~}
-      [[ "$dir" = */* ]] && dir="${dir%/*}" || dir="."
-      : ${dir:=/}
-      _cdbrowse "$dir" 4
-      return 0
-    ;;
-    '[1;2D') # shift left
-      [[ "$dir" = \~* ]] && dir="$HOME"${dir#\~}
-      [[ "$dir" = */* ]] && dir="${dir%/*}" || dir="."
-      : ${dir:=/}
-      _cdbrowse "$dir" 1
-      return 0
-    ;;
     '[19~'|$'\x04'|'[3~') # F8 Ctl-D Del
       cddelete "$dir"
     ;;
-    '²')
-      _items=$(printf "%s\n" "${_aitems[@]}"|grep -E -v '^\.[^/]|/\.')
-      [ "$_items" ] || return 1
-      return 0
   esac
   return 2
 }
@@ -311,8 +267,8 @@ function cdsub {
   [ "$1" ] && gr=$($awk 'BEGIN{OFS=".*";for(i=1;i<ARGC;i++) $i=ARGV[i];print}' "$@")
   gr="${gr%/}"
   printf "%s" " Searching directories..." >&2
-  cdselect "$CDNBDIRS" "$(find -L "$orig" -xdev -mindepth 1 -maxdepth "$depth" -type d -print |\
-    sort -u |grep -- "$gr" 2>/dev/null;printf '\e[25D\e[K' >&2)" #_tput breaks old ksh
+  cdselect "$CDNBDIRS" "$(find -L "$orig" -xdev -mindepth 1 -maxdepth "$depth" -type d -print 2>/dev/null|\
+    sort -u |grep -- "$gr" 2>/dev/null|sed -e 's#^\./##';printf '\e[25D\e[K' >&2)" #_tput breaks old ksh
 }
 
 # use locate to get directories

--- a/lib/seedee
+++ b/lib/seedee
@@ -78,19 +78,6 @@ function cdselect
   [ "$dir" ] && cdpush "$dir"
 }
 
-_cdbrowse() {
-  typeset dir="$1" depth=${2:-1}
-
-  [[ $dir = \~* ]] && dir="$HOME"${dir#\~}
-  dir="${dir#../${PWD##*/}}"
-  : ${dir:=.}
-  $(\cd "$dir" >/dev/null 2>&1) || return
-  [ "$depth" = 4 ] && printf "Searching directories..." >&2
-  _items="$(find -L "$dir" -xdev -mindepth 1 -maxdepth "$depth" -type d -print 2>/dev/null|\
-    sed -e s"#^$HOME/#\~/#" -e 's#^\./##'|sort)"
-  _items_ori="$_items"
-}
-
 # selector custom keys
 _cd_keys()
 {

--- a/lib/selector
+++ b/lib/selector
@@ -77,6 +77,9 @@ _showmenu()
   typeset item icon fpath comment
   typeset -i i min max maxiw maxw maxcw w size
 
+  _nsel="${1:-$_nsel}"
+  ((_nsel < 1)) && _nsel=1
+  ((_nsel >= nbitems)) && ((_nsel=nbitems))
   _menuprompt
   lines=${_maxlines:-$LINES}
   ((lines >= LINES)) && ((lines=LINES-1))
@@ -125,16 +128,6 @@ _showmenu()
   _tput ed
   _tput cuu $size
   printf "\r" # begin of line
-}
-
-_select()
-{
-  typeset newsel="$1"
-
-  ((_nsel=newsel))
-  ((_nsel <1 )) && _nsel=1
-  ((_nsel >= nbitems)) && _nsel=$nbitems
-  _showmenu
 }
 
 _items_split()
@@ -296,26 +289,25 @@ _domenu()
         _items_split "."
         filter=""
         nbitems=${#_aitems[@]}
-        _select "${_force_nsel:-1}"
+        _showmenu "${_force_nsel:-1}"
         _force_nsel=''
         continue;;
       1) break;;
       3) continue;;
     esac
-    echo "$key" >>/tmp/k
     case "$key" in
       '[A'|OA) #up
-        filter='';_select $((_nsel-1));;
+        filter='';_showmenu $((_nsel-1));;
       '[B'|OB) #down
-        filter='';_select $((_nsel+1));;
+        filter='';_showmenu $((_nsel+1));;
       '[H'|'[D'|OD|'[1;5H'|'[1;2D') #home or [shift] arrowleft
-        filter='';_select "1";;
+        filter='';_showmenu 1;;
       '[F'|'[C'|OC|'[1;5F'|'[1;2C') #end or [shift] arrowright
-        filter='';_select "$nbitems";;
+        filter='';_showmenu "$nbitems";;
       '[6~'|$'\x06'|'[1;2B') #pagedn Ctl-F shift-down
-        filter='';_select $((_nsel+lines-1));;
+        filter='';_showmenu $((_nsel+lines-1));;
       '[5~'|$'\x02'|'[1;2A') #pageup Ctl-B shift-up
-        filter='';_select $((_nsel-lines+1));;
+        filter='';_showmenu $((_nsel-lines+1));;
       '[19~'|$'\x04'|'[3~') # F8 Ctl-D delete
         unset "_aitems[$_nsel]"
         [ "$ZSH_VERSION" ] && _aitems=("${(@)_aitems[1,$_nsel-1]}" "${(@)_aitems[$_nsel+1,$nbitems]}") ||\
@@ -323,7 +315,7 @@ _domenu()
         nbitems=${#_aitems[@]}
         _tput ed
         [ "$nbitems" = 0 ] && break
-        filter='';_select "$_nsel";;
+        filter='';_showmenu "$_nsel";;
       $'\x7f'|$'\x08') #backspace
         filter="${filter%?}"
         _items="$_items_ori"

--- a/lib/selector
+++ b/lib/selector
@@ -91,6 +91,7 @@ _showmenu()
     ((${#item} > maxw)) && maxw=${#item}
   done
   ((maxw+=2))
+  [ "$_sel_option" ] && ((maxw+=3))
   w=${#nbitems}
   ((maxiw=COLUMNS-w-4))
   ((maxiw<0)) && maxiw=0
@@ -105,11 +106,11 @@ _showmenu()
       item="${item%%$'\t'*}"
     }
     icon=''
-    [ "$_sel_option" = filenames ] && {
-      [[ "$item" = \~/* ]] && fpath="$HOME/"${item#\~/} || fpath="$item"
-      if [ -L "$fpath" ]; then icon="$SELECTOR_LINK_ICON "
-      elif [ -d "$fpath" ] ;then icon="$SELECTOR_FOLDER_ICON "
-      else [ -e "$fpath" ] && icon="$SELECTOR_FILE_ICON ";fi
+    [ "$_sel_option" ] && {
+      _path_expand "$item"
+      if [ -L "$_path_expand" ]; then icon="$SELECTOR_LINK_ICON "
+      elif [ -d "$_path_expand" ] ;then icon="$SELECTOR_FOLDER_ICON "
+      else [ -e "$_path_expand" ] && icon="$SELECTOR_FILE_ICON ";fi
     }
     if ((_nsel == i)); then
       printf "$disp_item_sel" $w $i $maxw "$icon${item:0:$maxiw}" "${comment:0:$maxcw}"
@@ -169,6 +170,97 @@ _readkey()
   #printf "%s" "$key"
 }
 
+_path_expand() {
+  _path_expand="$1" _path_fprefix='' _path_rprefix=''
+  [[ $1 =~ ^[~$][A-Za-z0-9_]*(/|$) ]] && {
+    _path_fprefix="${1%%/*}"
+    _path_rprefix="$(IFS=;eval printf %s ${_path_fprefix:0:1}${_path_fprefix:1})"
+    _path_expand="$_path_rprefix${1#$_path_fprefix}"
+  }
+}
+
+_dirbrowse() {
+  typeset dir="$1" depth=${2:-1}
+  dir="${dir#../${PWD##*/}}"
+  : ${dir:=.}
+  $(\cd "$dir" >/dev/null 2>&1) || return 3
+  [ "$depth" = 4 ] && printf "Searching directories..." >&2
+  _items="$(find -L "$dir" -xdev -mindepth 1 -maxdepth "$depth" "${_find_type[@]}" -print 2>/dev/null|\
+    sed -e "s#^$_path_rprefix#$_path_fprefix#" -e s"#^$HOME/#\~/#" -e 's#^\./##' |sort)"
+  [ "$_items" ] && _items_ori="$_items" && return 0
+  _items="$_items_ori"
+  return 3
+}
+
+
+_file_keys() {
+  typeset k="$1" item="${_aitems[$_nsel]}"
+  _path_expand "$item"
+  item="$_path_expand"
+  case "$k" in
+    $'\t') # tab
+      selected="$item"
+      return 1
+    ;;
+    '[C'|OC) # right
+      [ ! "$filter" ] && _last_nsel=$_nsel
+      _dirbrowse "$item"
+      return $?
+    ;;
+    '[D'|OD) # left
+      _path_rprefix=''
+      _path_fprefix=''
+      [[ "$item" = */* ]] && item="${item%/*}" || item="."
+      : ${item:=/}
+      [ "$(\cd "$item" >/dev/null;pwd)" = / ] && item=/
+      case "$item" in
+        .) item='..';;
+        *(../)..|..) item="$item/..";;
+        */*) item="${item%/*}";: ${item:=/};;
+        *) item='.';;
+      esac
+      _dirbrowse "$item"
+      _force_nsel=$_last_nsel
+      unset _last_nsel
+      return 0
+    ;;
+    '[1;2C') # shift right
+      [[ "$item" = */* ]] && item="${item%/*}" || item="."
+      : ${item:=/}
+      _dirbrowse "$item" 4
+      return 0
+    ;;
+    '[1;2D') # shift left
+      [[ "$item" = */* ]] && item="${item%/*}" || item="."
+      : ${item:=/}
+      _dirbrowse "$item" 1
+      return 0
+    ;;
+    '²'|'OP') # F1
+      _items=$(printf "%s\n" "${_aitems[@]}"|grep -E -v '^\.[^/]|/\.')
+      [ "$_items" ] || return 1
+      return 0
+    ;;
+    'OR') # F3
+      _force_nsel=$_nsel
+      [ -r "$item" ] && [ -f "$item" ] || return 0
+      exec <&1
+      LESS='-+EX' ${PAGER:-less} "$item"
+      _tput civis
+      return 0
+    ;;
+    'OS') # F4
+      _force_nsel=$_nsel
+      [ -r "$item" ] && [ -f "$item" ] || return 0
+      exec <&1
+      ${EDITOR:-vi} "$item"
+      _tput civis
+      return 0
+    ;;
+  esac
+  return 2
+}
+
 _domenu()
 {
   typeset o=n _force_nsel
@@ -194,20 +286,22 @@ _domenu()
   while true
   do
     _readkey $o #$key
-    [ "$_keyfunc" ] && { # custom key control
-      $_keyfunc "$key" # 0: already managed / 1: managed exit / 2: default / 3: skip default
-      case "$?" in
-        0)
-          _items_split "."
-          filter=""
-          nbitems=${#_aitems[@]}
-          _select "${_force_nsel:-1}"
-          _force_nsel=''
-          continue;;
-        1) break;;
-        3) continue;;
-      esac
-    }
+    e=2
+    [ "$_sel_option" ] && { _file_keys "$key" ; e=$?; }
+    [ "$e" = 2 ] && [ "$_keyfunc" ] && { $_keyfunc "$key"; e=$?; }
+    # 0: already managed / 1: managed exit / 2: default / 3: skip default
+    case "$e" in
+      0)
+        _items_split "."
+        filter=""
+        nbitems=${#_aitems[@]}
+        _select "${_force_nsel:-1}"
+        _force_nsel=''
+        continue;;
+      1) break;;
+      3) continue;;
+    esac
+
     case "$key" in
       '[A'|OA) #up
         filter='';_select "_nsel-1";;
@@ -277,7 +371,7 @@ function selector
   typeset prompt filter
   typeset bg="\e[48;2;" fg="\e[38;2;" pl=""
   typeset wfg="$fg${SELECTOR_COL_TEXT}m"
-  typeset _items _aitems _maxlines _autofilter _keyfunc _sel_option _nsel _items_ori disp_item_sel disp_item disp_form key nbitems
+  typeset _items _aitems _maxlines _autofilter _keyfunc _sel_option _nsel _items_ori disp_item_sel disp_item disp_form key nbitems _find_type _path_expand _path_fprefix _path_rprefix e
   prompt='select'
   selected=''
   _maxlines=''
@@ -313,6 +407,7 @@ function selector
         ;;
       -o|--option)
         [ "$2" ] && _sel_option="$2" || return 1
+        [ "$_sel_option" = dirnames ] && _find_type=(-type d) || _find_type=()
         ;;
       *)
         printf "usage: selector [-p <prompt>] -i <items>|-f <itemfile> [-P <y|n>] [-k <keyfunc>]\n"

--- a/lib/selector
+++ b/lib/selector
@@ -75,7 +75,7 @@ _menuprompt()
 _showmenu()
 {
   typeset item icon fpath comment
-  typeset -i i min max maxiw maxw maxcw lines w size
+  typeset -i i min max maxiw maxw maxcw w size
 
   _menuprompt
   lines=${_maxlines:-$LINES}
@@ -264,6 +264,7 @@ _file_keys() {
 _domenu()
 {
   typeset o=n _force_nsel
+  typeset -i lines
   _nsel=''
   printf "\r"
   _tput el
@@ -301,20 +302,20 @@ _domenu()
       1) break;;
       3) continue;;
     esac
-
+    echo "$key" >>/tmp/k
     case "$key" in
       '[A'|OA) #up
-        filter='';_select "_nsel-1";;
+        filter='';_select $((_nsel-1));;
       '[B'|OB) #down
-        filter='';_select "_nsel+1";;
+        filter='';_select $((_nsel+1));;
       '[H'|'[D'|OD|'[1;5H'|'[1;2D') #home or [shift] arrowleft
         filter='';_select "1";;
       '[F'|'[C'|OC|'[1;5F'|'[1;2C') #end or [shift] arrowright
-        filter='';_select "nbitems";;
+        filter='';_select "$nbitems";;
       '[6~'|$'\x06'|'[1;2B') #pagedn Ctl-F shift-down
-        filter='';_select "_nsel+lines-1";;
+        filter='';_select $((_nsel+lines-1));;
       '[5~'|$'\x02'|'[1;2A') #pageup Ctl-B shift-up
-        filter='';_select "_nsel-lines+1";;
+        filter='';_select $((_nsel-lines+1));;
       '[19~'|$'\x04'|'[3~') # F8 Ctl-D delete
         unset "_aitems[$_nsel]"
         [ "$ZSH_VERSION" ] && _aitems=("${(@)_aitems[1,$_nsel-1]}" "${(@)_aitems[$_nsel+1,$nbitems]}") ||\

--- a/lib/selector
+++ b/lib/selector
@@ -212,13 +212,13 @@ _file_keys() {
       _path_fprefix=''
       [[ "$item" = */* ]] && item="${item%/*}" || item="."
       : ${item:=/}
-      [ "$(\cd "$item" >/dev/null;pwd)" = / ] && item=/
       case "$item" in
         .) item='..';;
-        *(../)..|..) item="$item/..";;
+        ../*|..) item="$item/..";;
         */*) item="${item%/*}";: ${item:=/};;
         *) item='.';;
       esac
+      [ "$(\cd "$item" >/dev/null;pwd)" = / ] && item=/
       _dirbrowse "$item"
       _force_nsel=$_last_nsel
       unset _last_nsel


### PR DESCRIPTION
* selector managing files/dirs navigation (-o filenames|dirnames)
* refactor complete-ng bash/zsh to use selector instead of specific implementation
* refactor seedee to use selector instead of specific implementation